### PR TITLE
feat: Add Release project@version if release is not set.

### DIFF
--- a/Sentry.Xamarin.Forms/Internals/NativeEventProcessor.droid.cs
+++ b/Sentry.Xamarin.Forms/Internals/NativeEventProcessor.droid.cs
@@ -103,7 +103,7 @@ namespace Sentry.Xamarin.Forms.Internals
             }
             else
             {
-                _options.DiagnosticLogger.Log(SentryLevel.Debug, "AndroidEventProcessor disabled due to previous error.");
+                _options.DiagnosticLogger?.Log(SentryLevel.Debug, "AndroidEventProcessor disabled due to previous error.");
             }
             return @event;
         }

--- a/Sentry.Xamarin.Forms/Internals/NativeEventProcessor.ios.cs
+++ b/Sentry.Xamarin.Forms/Internals/NativeEventProcessor.ios.cs
@@ -46,7 +46,7 @@ namespace Sentry.Xamarin.Forms.Internals
             }
             else
             {
-                _options.DiagnosticLogger.Log(SentryLevel.Debug, "iOSEventProcessor disabled due to previous error.");
+                _options.DiagnosticLogger?.Log(SentryLevel.Debug, "iOSEventProcessor disabled due to previous error.");
             }
             return @event;
         }

--- a/Sentry.Xamarin.Forms/Internals/NativeEventProcessor.uwp.cs
+++ b/Sentry.Xamarin.Forms/Internals/NativeEventProcessor.uwp.cs
@@ -63,7 +63,7 @@ namespace Sentry.Xamarin.Forms.Internals
             }
             else
             {
-                _options.DiagnosticLogger.Log(SentryLevel.Debug, "UwpPlatformEventProcessor disabled due to previous error.");
+                _options.DiagnosticLogger?.Log(SentryLevel.Debug, "UwpPlatformEventProcessor disabled due to previous error.");
             }
             return @event;
         }

--- a/Sentry.Xamarin.Forms/Internals/NativeIntegration.droid.cs
+++ b/Sentry.Xamarin.Forms/Internals/NativeIntegration.droid.cs
@@ -28,7 +28,7 @@ namespace Sentry.Xamarin.Forms.Internals
             }
             catch (Exception ex)
             {
-                options.DiagnosticLogger.Log(SentryLevel.Error, "Sentry.Xamarin.Forms failed to attach AtivityStateChanged", ex);
+                options.DiagnosticLogger?.Log(SentryLevel.Error, "Sentry.Xamarin.Forms failed to attach AtivityStateChanged", ex);
                 _xamarinOptions.NativeIntegrationEnabled = false;
             }
         }

--- a/Sentry.Xamarin.Forms/Internals/XamarinFormsEventProcessor.cs
+++ b/Sentry.Xamarin.Forms/Internals/XamarinFormsEventProcessor.cs
@@ -105,7 +105,7 @@ namespace Sentry.Xamarin.Forms.Internals
             }
             else
             {
-                _options.DiagnosticLogger.Log(SentryLevel.Debug, "FormsEventProcessor disabled due to previous error.");
+                _options.DiagnosticLogger?.Log(SentryLevel.Debug, "FormsEventProcessor disabled due to previous error.");
             }
             return @event;
         }

--- a/Sentry.Xamarin.Forms/SentryXamarinFormsIntegration.cs
+++ b/Sentry.Xamarin.Forms/SentryXamarinFormsIntegration.cs
@@ -16,7 +16,6 @@ namespace Sentry.Xamarin.Forms
     /// </summary>
     public class SentryXamarinFormsIntegration : ISdkIntegration
     {
-        #region Properties
         internal static Lazy<SentryXamarinOptions> Options = new Lazy<SentryXamarinOptions>();
         internal static SentryXamarinFormsIntegration Instance;
         internal static DelegateLogListener XamarinLogger;
@@ -31,8 +30,6 @@ namespace Sentry.Xamarin.Forms
         internal NativeIntegration Nativeintegration { get; private set; }
 #endif
 
-        #endregion
-        #region Register/Hooks
         /// <summary>
         /// Register the Sentry Xamarin Forms SDK on Sentry.NET SDK
         /// </summary>
@@ -136,9 +133,6 @@ namespace Sentry.Xamarin.Forms
             return Application.Current;
         }
 
-        #endregion
-        #region Events
-
         private void Current_RequestedThemeChanged(object sender, AppThemeChangedEventArgs e)
         {
             _hub.AddBreadcrumb(e.RequestedTheme.ToString(), "AppTheme.Change", level: BreadcrumbLevel.Info);
@@ -191,6 +185,5 @@ namespace Sentry.Xamarin.Forms
             }
             CurrentPage = pageType.Name;
         }
-        #endregion
     }
 }

--- a/Tests/Sentry.Xamarin.Forms.Tests.UWP/Internals/NativeIntegrationTests.cs
+++ b/Tests/Sentry.Xamarin.Forms.Tests.UWP/Internals/NativeIntegrationTests.cs
@@ -1,12 +1,6 @@
 ﻿using Moq;
-using Sentry.Protocol;
 using Sentry.Xamarin.Forms.Internals;
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using Windows.UI.WebUI;
-using Windows.UI.Xaml;
 using Xunit;
 
 namespace Sentry.Xamarin.Forms.Tests.UWP.Internals

--- a/Tests/Sentry.Xamarin.Forms.Tests.UWP/Sentry.Xamarin.Forms.Tests.UWP.csproj
+++ b/Tests/Sentry.Xamarin.Forms.Tests.UWP/Sentry.Xamarin.Forms.Tests.UWP.csproj
@@ -123,6 +123,7 @@
     <Compile Include="Internals\NativeEventProcessorTests.cs" />
     <Compile Include="Internals\NativeIntegrationTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SentryXamarinFormsIntegrationTests.cs" />
     <Compile Include="UnitTestApp.xaml.cs">
       <DependentUpon>UnitTestApp.xaml</DependentUpon>
     </Compile>

--- a/Tests/Sentry.Xamarin.Forms.Tests.UWP/SentryXamarinFormsIntegrationTests.cs
+++ b/Tests/Sentry.Xamarin.Forms.Tests.UWP/SentryXamarinFormsIntegrationTests.cs
@@ -1,0 +1,72 @@
+﻿using Sentry.Xamarin.Forms.Internals;
+using Xunit;
+
+namespace Sentry.Xamarin.Forms.Tests.UWP
+{
+    public class SentryXamarinFormsIntegrationTests
+    {
+        [Fact]
+        public void ConfigureSentryOptions_ReleaseSetIfNotInformed()
+        {
+            //Arrange
+            var options = new SentryOptions();
+            options.Release = null;
+            var integration = new SentryXamarinFormsIntegration();
+
+            //Act
+            integration.ConfigureSentryOptions(options);
+
+            //Assert
+            Assert.NotNull(options.Release);
+        }
+
+        [Fact]
+        public void ConfigureSentryOptions_ReleaseNotSetIfInformed()
+        {
+            //Arrange
+            var options = new SentryOptions();
+            options.Release = "myrelease@1.1";
+            var integration = new SentryXamarinFormsIntegration();
+
+            //Act
+            integration.ConfigureSentryOptions(options);
+
+            //Assert
+            Assert.Equal(options.Release, options.Release);
+        }
+        
+        [Fact]
+        public void RegisterNativeIntegrations_NativeIntegrationEnabled_NativeIntegrationRegistered()
+        {
+            //Arrange
+            var options = new SentryOptions();
+            var xamarinOptions = new SentryXamarinOptions();
+            var integration = new SentryXamarinFormsIntegration();
+
+            //Act
+            integration.RegisterNativeIntegrations(default, options, xamarinOptions);
+            integration.Nativeintegration.Unregister();
+
+            //Assert
+            Assert.NotNull(integration.Nativeintegration);
+        }
+
+        [Fact]
+        public void RegisterNativeIntegrations_NativeIntegrationDisabled_NativeIntegrationNotSet()
+        {
+            //Arrange
+            var options = new SentryOptions();
+            var xamarinOptions = new SentryXamarinOptions()
+            {
+                NativeIntegrationEnabled = false
+            };
+            var integration = new SentryXamarinFormsIntegration();
+
+            //Act
+            integration.RegisterNativeIntegrations(default, options, xamarinOptions);
+
+            //Assert
+            Assert.Null(integration.Nativeintegration);
+        }
+    }
+}


### PR DESCRIPTION
I Also refactored SentryXamarinFormsIntegration to allow more testing.

Closes #22.

The release format is: 

iOS: "{app packagename}"@{app number}"
Android: "{app packagename}"@{app number}"
UWP: "{app GUID}"@{app number}"