### PR TITLE
ref: Remove the ToUpper on platform

### DIFF
--- a/Sentry.Xamarin.Forms/Internals/XamarinFormsEventProcessor.cs
+++ b/Sentry.Xamarin.Forms/Internals/XamarinFormsEventProcessor.cs
@@ -37,7 +37,7 @@ namespace Sentry.Xamarin.Forms.Internals
             {
                 Manufacturer = DeviceInfo.Manufacturer.FilterUnknownOrEmpty();
                 Model = DeviceInfo.Model.FilterUnknownOrEmpty();
-                Platform = DeviceInfo.Platform.ToString().ToUpper();
+                Platform = DeviceInfo.Platform.ToString();
                 PlatformVersion = DeviceInfo.VersionString;
                 IsEmulator = DeviceInfo.DeviceType != DeviceType.Physical;
                 Type = DeviceInfo.Idiom.ToString();


### PR DESCRIPTION
I forgot to remove the ToUpper...

https://sentry.io/organizations/sentry-sdks/issues/2096393321/events/08f4d92c9c3243e4b16b591b5d658ec6/

proof it got fixed.