### PR TITLE
ref: Bump SentrySDK version and fixed test for .NET Native

### DIFF
--- a/Samples/Sample.Xamarin.Core/Extensions/SentryIdExtensions.cs
+++ b/Samples/Sample.Xamarin.Core/Extensions/SentryIdExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Sentry.Protocol;
+﻿using Sentry;
 using System;
 //Based on https://github.com/csharpvitamins/CSharpVitamins.ShortGuid
 

--- a/Samples/Sample.Xamarin.Core/Sample.Xamarin.Core.csproj
+++ b/Samples/Sample.Xamarin.Core/Sample.Xamarin.Core.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Rg.Plugins.Popup" Version="2.0.0.9" />
-    <PackageReference Include="Sentry" Version="3.0.0-alpha.6" />
+    <PackageReference Include="Sentry" Version="3.0.0-alpha.8" />
     <PackageReference Include="Xamanimation" Version="1.3.0" />
     <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
     <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />

--- a/Samples/Sample.Xamarin.Droid/Sample.Xamarin.Droid.csproj
+++ b/Samples/Sample.Xamarin.Droid/Sample.Xamarin.Droid.csproj
@@ -59,7 +59,7 @@
       <Version>2.0.0.9</Version>
     </PackageReference>
     <PackageReference Include="Sentry">
-      <Version>3.0.0-alpha.6</Version>
+      <Version>3.0.0-alpha.8</Version>
     </PackageReference>
     <PackageReference Include="System.Net.Http">
       <Version>4.3.4</Version>

--- a/Samples/Sample.Xamarin.iOS/Sample.Xamarin.iOS.csproj
+++ b/Samples/Sample.Xamarin.iOS/Sample.Xamarin.iOS.csproj
@@ -127,7 +127,7 @@
       <Version>2.0.0.9</Version>
     </PackageReference>
     <PackageReference Include="Sentry">
-      <Version>3.0.0-alpha.6</Version>
+      <Version>3.0.0-alpha.8</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
     <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />

--- a/Sentry.Xamarin.Forms/Sentry.Xamarin.Forms.csproj
+++ b/Sentry.Xamarin.Forms/Sentry.Xamarin.Forms.csproj
@@ -43,7 +43,7 @@
 	</ItemGroup>
 	
 	<ItemGroup>
-		<PackageReference Include="Sentry" Version="3.0.0-alpha.6" />
+		<PackageReference Include="Sentry" Version="3.0.0-alpha.8" />
 		<PackageReference Include="Xamarin.Essentials" Version="1.4.0" />
 		<PackageReference Include="Xamarin.Forms" Version="4.6.0.726" />
 	</ItemGroup>

--- a/Tests/Sentry.Xamarin.Forms.Tests.UWP/Internals/NativeIntegrationTests.cs
+++ b/Tests/Sentry.Xamarin.Forms.Tests.UWP/Internals/NativeIntegrationTests.cs
@@ -77,12 +77,7 @@ namespace Sentry.Xamarin.Forms.Tests.UWP.Internals
             //Act
             try
             {
-
                 integration.Handle(new Exception());
-            }
-            catch (Exception)
-            {
-                throw;
             }
             finally
             {

--- a/Tests/Sentry.Xamarin.Forms.Tests.UWP/Internals/NativeIntegrationTests.cs
+++ b/Tests/Sentry.Xamarin.Forms.Tests.UWP/Internals/NativeIntegrationTests.cs
@@ -1,12 +1,59 @@
 ﻿using Moq;
+using Sentry.Protocol;
 using Sentry.Xamarin.Forms.Internals;
 using System;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Sentry.Xamarin.Forms.Tests.UWP.Internals
 {
     public class NativeIntegrationTests
     {
+        /// <summary>
+        /// Mock is not supported by .NET Native so we have to manually Mock the Hub.
+        /// </summary>
+        private class MockHub : IHub
+        {
+            public SentryId LastEventId => throw new NotImplementedException();
+
+            public int CaptureEventCount = 0;
+            public int FlushAsyncCount = 0;
+
+            public bool IsEnabled => true;
+
+            public void BindClient(ISentryClient client) { }
+
+            public SentryId CaptureEvent(SentryEvent evt, Scope scope = null)
+            {
+                CaptureEventCount++;
+                return evt.EventId;
+            }
+
+            public void CaptureTransaction(Transaction transaction) { }
+
+            public void CaptureUserFeedback(UserFeedback userFeedback) { }
+
+            public void ConfigureScope(Action<Scope> configureScope) { }
+
+            public Task ConfigureScopeAsync(Func<Scope, Task> configureScope) => null;
+
+            public Transaction CreateTransaction(string name, string operation) => null;
+
+            public Task FlushAsync(TimeSpan timeout)
+            {
+                FlushAsyncCount++;
+                return Task.Run(() => { });
+            }
+
+            public SentryTraceHeader GetSentryTrace() => null;
+
+            public IDisposable PushScope() => null;
+
+            public IDisposable PushScope<TState>(TState state) => null;
+
+            public void WithScope(Action<Scope> scopeCallback) { }
+        }
+
         [Fact]
         public void Unregister_DoesntCrashifNotRegistered()
         {
@@ -18,16 +65,14 @@ namespace Sentry.Xamarin.Forms.Tests.UWP.Internals
         }
 
         [Fact]
-        public void OnSleep_SleepBreadcrumb()
+        public void Handle_RegisterUnhandleException()
         {
             //Arrange
             var integration = new NativeIntegration(new SentryXamarinOptions());
-            var hub = new Mock<IHub>();
-            hub.Setup(x => x.IsEnabled).Returns(true);
-            var hubObj = hub.Object;
+            var hub = new MockHub();
 
             var exception = new Exception();
-            integration.Register(hubObj, new SentryOptions());
+            integration.Register(hub, new SentryOptions());
 
             //Act
             try
@@ -35,14 +80,18 @@ namespace Sentry.Xamarin.Forms.Tests.UWP.Internals
 
                 integration.Handle(new Exception());
             }
+            catch (Exception)
+            {
+                throw;
+            }
             finally
             {
                 integration.Unregister();
             }
 
             //Assert
-            hub.Verify(x => x.CaptureEvent(It.IsAny<SentryEvent>(), null), Times.Once());
-            hub.Verify(x => x.FlushAsync(It.IsAny<TimeSpan>()), Times.Once());
+            Assert.Equal(1, hub.CaptureEventCount);
+            Assert.Equal(1, hub.FlushAsyncCount);
         }
     }
 }


### PR DESCRIPTION
- min version is 3.0.0 Alpha 8 (there were some breaking changes between version 6 and 8)
-  Fixed tests for .NET Native.