### PR TITLE
ref: Initializer refactory

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ Additionaly, Android and IOS will include additional information:
 </p>
 
 ## Setup
-All you need to do is to Add the Xamarin integration to SentryOptions and it's recommended to start the Sentry SDK as early as possible, for an example, the start of OnCreate on MainActivity for Android, and , the top of FinishedLaunching on AppDelegate for iOS)
+All you need to do is to initialize Xamarin integration by calling SentryXamarin.Init, and, it's recommended to start Sentry Xamarin SDK as early as possible, for an example, the start of OnCreate on MainActivity for Android, and, the top of FinishedLaunching on AppDelegate for iOS)
 
 ```C#
-SentrySdk.Init(o =>
+SentryXamarin.Init(options =>
 {
-    o.Dsn = new Dsn("yourdsn");
+    options.Dsn = "__YOUR__DSN__";
     o.AddIntegration(new SentryXamarinFormsIntegration());
 });
 
@@ -60,11 +60,9 @@ public class MainActivity : global::Xamarin.Forms.Platform.Android.FormsAppCompa
 {
     protected override void OnCreate(Bundle savedInstanceState)
     {
-        SentrySdk.Init(o =>
+        SentryXamarin.Init(options =>
         {
-            o.Dsn = new Dsn("yourdsn");
-            o.CacheDirectoryPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-            o.AddIntegration(new SentryXamarinFormsIntegration());
+            options.Dsn = "__YOUR__DSN__";
         });
         ...
 ```
@@ -76,28 +74,24 @@ public partial class AppDelegate : global::Xamarin.Forms.Platform.iOS.FormsAppli
 {
     public override bool FinishedLaunching(UIApplication app, NSDictionary options)
     {
-        SentrySdk.Init(o =>
+        SentryXamarin.Init(options =>
         {
-            o.Dsn = new Dsn("yourdsn");
-            o.CacheDirectoryPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-            o.AddIntegration(new SentryXamarinFormsIntegration());
+            options.Dsn = "__YOUR__DSN__";
         });
         ...
 ```
 
 ### UWP
-Note: It's recommended to not setup the CacheDirectory due to an issue with Sentry SDK
 On App.Xaml.cs
 ```C#
     sealed partial class App : Application
     {
         protected override void OnLaunched(LaunchActivatedEventArgs e)
         {
-        SentrySdk.Init(o =>
-        {
-            o.Dsn = new Dsn("yourdsn");
-            o.AddIntegration(new SentryXamarinFormsIntegration());
-        });
+            SentryXamarin.Init(options =>
+            {
+                options.Dsn = "__YOUR__DSN__";
+            });
         ...        
 ```
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ All you need to do is to initialize Xamarin integration by calling SentryXamarin
 SentryXamarin.Init(options =>
 {
     options.Dsn = "__YOUR__DSN__";
-    o.AddIntegration(new SentryXamarinFormsIntegration());
 });
 
 ```

--- a/Samples/Sample.Xamarin.Core/Helpers/SentryInitializer.cs
+++ b/Samples/Sample.Xamarin.Core/Helpers/SentryInitializer.cs
@@ -1,21 +1,18 @@
 ﻿using Sentry;
-using Sentry.Xamarin.Forms;
-using System;
-using System.IO;
 
 namespace Sample.Xamarin.Core.Helpers
 {
     public static class SentryInitializer
     {
-        public static void Init(bool enableCache = true)
+        public static void Init()
         {
-            var path = enableCache ? Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) : null;
-            SentrySdk.Init(o =>
+            SentryXamarin.Init(options =>
             {
-                o.CacheDirectoryPath = path;
-                o.Debug = true;
-                o.Dsn = "https://5a193123a9b841bc8d8e42531e7242a1@o447951.ingest.sentry.io/5560112";
-                o.AddIntegration(new SentryXamarinFormsIntegration());
+                options.Dsn = "https://5a193123a9b841bc8d8e42531e7242a1@o447951.ingest.sentry.io/5560112";
+#if DEBUG
+                options.DiagnosticLogger = new Sentry.Infrastructure.DebugDiagnosticLogger(SentryLevel.Debug);
+                options.Debug = true;
+#endif
             });
         }
     }

--- a/Samples/Sample.Xamarin.Core/Helpers/SentryInitializer.cs
+++ b/Samples/Sample.Xamarin.Core/Helpers/SentryInitializer.cs
@@ -10,7 +10,6 @@ namespace Sample.Xamarin.Core.Helpers
             {
                 options.Dsn = "https://5a193123a9b841bc8d8e42531e7242a1@o447951.ingest.sentry.io/5560112";
 #if DEBUG
-                options.DiagnosticLogger = new Sentry.Infrastructure.DebugDiagnosticLogger(SentryLevel.Debug);
                 options.Debug = true;
 #endif
             });

--- a/Samples/Sample.Xamarin.UWP/App.xaml.cs
+++ b/Samples/Sample.Xamarin.UWP/App.xaml.cs
@@ -12,7 +12,7 @@ namespace Sample.Xamarin.uwp
     {
         protected override void OnLaunched(LaunchActivatedEventArgs e)
         {
-            SentryInitializer.Init(false);
+            SentryInitializer.Init();
             Frame rootFrame = Window.Current.Content as Frame;
 
             if (rootFrame == null)

--- a/Sentry.Xamarin.Forms/Extensions/SentryOptionsExtensions.cs
+++ b/Sentry.Xamarin.Forms/Extensions/SentryOptionsExtensions.cs
@@ -1,5 +1,8 @@
 ﻿using Sentry.Xamarin.Forms;
 using Sentry.Xamarin.Forms.Extensions;
+using Sentry.Xamarin.Forms.Internals;
+using System;
+using Xamarin.Essentials;
 
 namespace Sentry
 {
@@ -8,13 +11,15 @@ namespace Sentry
     /// </summary>
     public static class SentryOptionsExtensions
     {
+        private static Lazy<string> _internalCacheDefaultPath = new Lazy<string>(()=> Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData));
+
         /// <summary>
         /// Disables the automatic Xamarin warning crumbs.
         /// </summary>
         /// <param name="options">The Sentry options.</param>
         public static void DisableXamarinWarningsBreadcrumbs(this SentryOptions options)
         {
-            SentryXamarinFormsIntegration.Options.Value.XamarinLoggerEnabled = false;
+            options.GetSentryXamarinOptions().XamarinLoggerEnabled = false;
         }
 
         /// <summary>
@@ -23,7 +28,43 @@ namespace Sentry
         /// <param name="options">The Sentry options.</param>
         public static void DisableNativeIntegration(this SentryOptions options)
         {
-            SentryXamarinFormsIntegration.Instance.UnregisterNativeIntegration();
+            SentryXamarinFormsIntegration.Instance.UnregisterNativeIntegration(options.GetSentryXamarinOptions());
         }
+
+        /// <summary>
+        /// Disables the cache, must be called before Sentry gets initialized
+        /// </summary>
+        /// <param name="options">The Sentry options.</param>
+        public static void DisableXamarinFormsCache(this SentryOptions options)
+        {
+            options.GetSentryXamarinOptions().InternalCacheEnabled = false;
+        }
+
+        internal static SentryXamarinOptions GetSentryXamarinOptions(this SentryOptions options)
+            => SentryXamarin.Options;
+
+        internal static string DefaultCacheDirectoyPath(this SentryOptions options)
+            => _internalCacheDefaultPath.Value;
+
+        internal static void ConfigureSentryXamarinOptions(this SentryOptions options, SentryXamarinOptions xamarinOptions)
+        {
+            options.Release ??= $"{AppInfo.PackageName}@{AppInfo.VersionString}";
+            if (xamarinOptions.InternalCacheEnabled)
+            {
+                options.CacheDirectoryPath ??= options.DefaultCacheDirectoyPath();
+            }
+        }
+
+        internal static void RegisterXamarinEventProcessors(this SentryOptions options)
+        {
+            options.AddEventProcessor(new XamarinFormsEventProcessor(options));
+
+#if NATIVE_PROCESSOR
+            options.AddEventProcessor(new NativeEventProcessor(options));
+#else
+            options.DiagnosticLogger?.Log(SentryLevel.Debug, "No NativeEventProcessor found for the given target.");
+#endif
+        }
+
     }
 }

--- a/Sentry.Xamarin.Forms/Extensions/SentryOptionsExtensions.cs
+++ b/Sentry.Xamarin.Forms/Extensions/SentryOptionsExtensions.cs
@@ -41,15 +41,15 @@ namespace Sentry
         }
 
         internal static SentryXamarinOptions GetSentryXamarinOptions(this SentryOptions options)
-            => SentryXamarin.Options;
+            => options is SentryXamarinOptions xamarinOptions ? xamarinOptions : SentryXamarin.Options;
 
         internal static string DefaultCacheDirectoyPath(this SentryOptions options)
             => _internalCacheDefaultPath.Value;
 
-        internal static void ConfigureSentryXamarinOptions(this SentryOptions options, SentryXamarinOptions xamarinOptions)
+        internal static void ConfigureSentryXamarinOptions(this SentryXamarinOptions options)
         {
             options.Release ??= $"{AppInfo.PackageName}@{AppInfo.VersionString}";
-            if (xamarinOptions.InternalCacheEnabled)
+            if (options.InternalCacheEnabled)
             {
                 options.CacheDirectoryPath ??= options.DefaultCacheDirectoyPath();
             }

--- a/Sentry.Xamarin.Forms/Extensions/SentryXamarinFormsIntegrationExtensions.cs
+++ b/Sentry.Xamarin.Forms/Extensions/SentryXamarinFormsIntegrationExtensions.cs
@@ -1,13 +1,15 @@
-﻿namespace Sentry.Xamarin.Forms.Extensions
+﻿using Sentry.Xamarin.Forms.Internals;
+
+namespace Sentry.Xamarin.Forms.Extensions
 {
     internal static class SentryXamarinFormsIntegrationExtensions
     {
-        internal static void UnregisterNativeIntegration(this SentryXamarinFormsIntegration integration)
+        internal static void UnregisterNativeIntegration(this SentryXamarinFormsIntegration integration, SentryXamarinOptions options)
         {
 #if NATIVE_PROCESSOR
             integration?.Nativeintegration?.Unregister();
 #endif
-            SentryXamarinFormsIntegration.Options.Value.NativeIntegrationEnabled = false;
+            options.NativeIntegrationEnabled = false;
         }
     }
 }

--- a/Sentry.Xamarin.Forms/Extensions/SentryXamarinOptionsExtensions.cs
+++ b/Sentry.Xamarin.Forms/Extensions/SentryXamarinOptionsExtensions.cs
@@ -7,9 +7,9 @@ using Xamarin.Essentials;
 namespace Sentry
 {
     /// <summary>
-    /// Extend SentryOptions by allowing it to manipulate options from Sentry Xamarin Forms.
+    /// Extend SentryXamarinOptions by allowing it to manipulate options from Sentry Xamarin Forms.
     /// </summary>
-    public static class SentryOptionsExtensions
+    public static class SentryXamarinOptionsExtensions
     {
         private static Lazy<string> _internalCacheDefaultPath = new Lazy<string>(()=> Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData));
 
@@ -17,33 +17,30 @@ namespace Sentry
         /// Disables the automatic Xamarin warning crumbs.
         /// </summary>
         /// <param name="options">The Sentry options.</param>
-        public static void DisableXamarinWarningsBreadcrumbs(this SentryOptions options)
+        public static void DisableXamarinWarningsBreadcrumbs(this SentryXamarinOptions options)
         {
-            options.GetSentryXamarinOptions().XamarinLoggerEnabled = false;
+            options.XamarinLoggerEnabled = false;
         }
 
         /// <summary>
         /// Disables the Sentry Xamarin Forms Native integration.
         /// </summary>
         /// <param name="options">The Sentry options.</param>
-        public static void DisableNativeIntegration(this SentryOptions options)
+        public static void DisableNativeIntegration(this SentryXamarinOptions options)
         {
-            SentryXamarinFormsIntegration.Instance.UnregisterNativeIntegration(options.GetSentryXamarinOptions());
+            SentryXamarinFormsIntegration.Instance.UnregisterNativeIntegration(options);
         }
 
         /// <summary>
         /// Disables the cache, must be called before Sentry gets initialized
         /// </summary>
         /// <param name="options">The Sentry options.</param>
-        public static void DisableXamarinFormsCache(this SentryOptions options)
+        public static void DisableXamarinFormsCache(this SentryXamarinOptions options)
         {
-            options.GetSentryXamarinOptions().InternalCacheEnabled = false;
+            options.InternalCacheEnabled = false;
         }
 
-        internal static SentryXamarinOptions GetSentryXamarinOptions(this SentryOptions options)
-            => options is SentryXamarinOptions xamarinOptions ? xamarinOptions : SentryXamarin.Options;
-
-        internal static string DefaultCacheDirectoyPath(this SentryOptions options)
+        internal static string DefaultCacheDirectoyPath(this SentryXamarinOptions options)
             => _internalCacheDefaultPath.Value;
 
         internal static void ConfigureSentryXamarinOptions(this SentryXamarinOptions options)
@@ -55,7 +52,7 @@ namespace Sentry
             }
         }
 
-        internal static void RegisterXamarinEventProcessors(this SentryOptions options)
+        internal static void RegisterXamarinEventProcessors(this SentryXamarinOptions options)
         {
             options.AddEventProcessor(new XamarinFormsEventProcessor(options));
 
@@ -65,6 +62,5 @@ namespace Sentry
             options.DiagnosticLogger?.Log(SentryLevel.Debug, "No NativeEventProcessor found for the given target.");
 #endif
         }
-
     }
 }

--- a/Sentry.Xamarin.Forms/Internals/NativeIntegration.uwp.cs
+++ b/Sentry.Xamarin.Forms/Internals/NativeIntegration.uwp.cs
@@ -1,5 +1,4 @@
-﻿using Sentry.Infrastructure;
-using Sentry.Integrations;
+﻿using Sentry.Integrations;
 using Sentry.Protocol;
 using System;
 using System.Runtime.ExceptionServices;
@@ -24,8 +23,6 @@ namespace Sentry.Xamarin.Forms.Internals
         public void Register(IHub hub, SentryOptions options) 
         {
             _hub = hub;
-
-            options.DiagnosticLogger = new DebugDiagnosticLogger(options.DiagnosticsLevel);
 
             _application = Application.Current;
             if (_application != null)

--- a/Sentry.Xamarin.Forms/Internals/SentryXamarinOptions.cs
+++ b/Sentry.Xamarin.Forms/Internals/SentryXamarinOptions.cs
@@ -4,5 +4,6 @@
     {
         internal bool XamarinLoggerEnabled { get; set; } = true;
         internal bool NativeIntegrationEnabled { get; set; } = true;
+        internal bool InternalCacheEnabled { get; set; } = true;
     }
 }

--- a/Sentry.Xamarin.Forms/SentryXamarin.cs
+++ b/Sentry.Xamarin.Forms/SentryXamarin.cs
@@ -1,5 +1,4 @@
 ﻿using Sentry.Xamarin.Forms;
-using Sentry.Xamarin.Forms.Internals;
 using System;
 
 namespace Sentry
@@ -13,7 +12,6 @@ namespace Sentry
     /// </remarks>
     public static class SentryXamarin
     {
-        internal static SentryXamarinOptions Options { get; set; }
 
         /// <summary>
         /// Initializes the SDK with an optional configuration options callback.
@@ -33,11 +31,10 @@ namespace Sentry
         public static void Init(SentryXamarinOptions options)
         {
             options ??= new SentryXamarinOptions();
-            Options = options;
 
             options.ConfigureSentryXamarinOptions();
             options.RegisterXamarinEventProcessors();
-            options.AddIntegration(new SentryXamarinFormsIntegration(Options));
+            options.AddIntegration(new SentryXamarinFormsIntegration(options));
 
             SentrySdk.Init(options);
         }

--- a/Sentry.Xamarin.Forms/SentryXamarin.cs
+++ b/Sentry.Xamarin.Forms/SentryXamarin.cs
@@ -1,0 +1,45 @@
+﻿using Sentry.Xamarin.Forms;
+using Sentry.Xamarin.Forms.Internals;
+using System;
+
+namespace Sentry
+{
+    /// <summary>
+    /// Sentry Xamarin SDK entrypoint.
+    /// </summary>
+    /// <remarks>
+    /// This is a facade to the SDK instance that also Initializes Sentry .NET SDK.
+    /// use SentrySdk for additional operations (like capturing exceptions, messages,...).
+    /// </remarks>
+    public static class SentryXamarin
+    {
+        internal static SentryXamarinOptions Options { get; set; }
+
+        /// <summary>
+        /// Initializes the SDK with an optional configuration options callback.
+        /// </summary>
+        /// <param name="configureOptions">The configure options.</param>
+        public static void Init(Action<SentryOptions> configureOptions)
+        {
+            var options = new SentryOptions();
+            configureOptions?.Invoke(options);
+            Init(options);
+        }
+
+        /// <summary>
+        /// Initializes the SDK with the specified options instance.
+        /// </summary>
+        /// <param name="options">The options instance</param>
+        public static void Init(SentryOptions options)
+        {
+            Options = new SentryXamarinOptions();           
+            options ??= new SentryOptions();
+
+            options.ConfigureSentryXamarinOptions(Options);
+            options.RegisterXamarinEventProcessors();
+            options.AddIntegration(new SentryXamarinFormsIntegration(Options));
+
+            SentrySdk.Init(options);
+        }
+    }
+}

--- a/Sentry.Xamarin.Forms/SentryXamarin.cs
+++ b/Sentry.Xamarin.Forms/SentryXamarin.cs
@@ -19,9 +19,9 @@ namespace Sentry
         /// Initializes the SDK with an optional configuration options callback.
         /// </summary>
         /// <param name="configureOptions">The configure options.</param>
-        public static void Init(Action<SentryOptions> configureOptions)
+        public static void Init(Action<SentryXamarinOptions> configureOptions)
         {
-            var options = new SentryOptions();
+            var options = new SentryXamarinOptions();
             configureOptions?.Invoke(options);
             Init(options);
         }
@@ -30,12 +30,12 @@ namespace Sentry
         /// Initializes the SDK with the specified options instance.
         /// </summary>
         /// <param name="options">The options instance</param>
-        public static void Init(SentryOptions options)
+        public static void Init(SentryXamarinOptions options)
         {
-            Options = new SentryXamarinOptions();           
-            options ??= new SentryOptions();
+            options ??= new SentryXamarinOptions();
+            Options = options;
 
-            options.ConfigureSentryXamarinOptions(Options);
+            options.ConfigureSentryXamarinOptions();
             options.RegisterXamarinEventProcessors();
             options.AddIntegration(new SentryXamarinFormsIntegration(Options));
 

--- a/Sentry.Xamarin.Forms/SentryXamarinFormsIntegration.cs
+++ b/Sentry.Xamarin.Forms/SentryXamarinFormsIntegration.cs
@@ -44,7 +44,7 @@ namespace Sentry.Xamarin.Forms
             }
             Instance = this;
             _hub = hub;
-            
+
             RegisterNativeIntegrations(hub, options, _options);
             RegisterXamarinLogListener(hub);
 

--- a/Sentry.Xamarin.Forms/SentryXamarinFormsIntegration.cs
+++ b/Sentry.Xamarin.Forms/SentryXamarinFormsIntegration.cs
@@ -3,22 +3,17 @@ using Sentry.Protocol;
 using Xamarin.Forms.Internals;
 using Sentry.Xamarin.Forms.Internals;
 using Xamarin.Forms;
-using System;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using Sentry.Xamarin.Forms.Extensions;
-using Xamarin.Essentials;
 
 namespace Sentry.Xamarin.Forms
 {
-    /// <summary>
-    /// Integration class for Sentry .NET SDK that you must call when initialzing SentrySDK.
-    /// </summary>
-    public class SentryXamarinFormsIntegration : ISdkIntegration
+    internal class SentryXamarinFormsIntegration : ISdkIntegration
     {
-        internal static Lazy<SentryXamarinOptions> Options = new Lazy<SentryXamarinOptions>();
         internal static SentryXamarinFormsIntegration Instance;
-        internal static DelegateLogListener XamarinLogger;
+        private SentryXamarinOptions _options;
+        private DelegateLogListener _xamarinLogger;
         private IHub _hub;
 
         /// <summary>
@@ -29,6 +24,11 @@ namespace Sentry.Xamarin.Forms
 #if NATIVE_PROCESSOR
         internal NativeIntegration Nativeintegration { get; private set; }
 #endif
+
+        internal SentryXamarinFormsIntegration(SentryXamarinOptions options)
+        {
+            _options = options;
+        }
 
         /// <summary>
         /// Register the Sentry Xamarin Forms SDK on Sentry.NET SDK
@@ -44,9 +44,8 @@ namespace Sentry.Xamarin.Forms
             }
             Instance = this;
             _hub = hub;
-            ConfigureSentryOptions(options);
-            RegisterEventProcessors(options);
-            RegisterNativeIntegrations(hub, options, Options.Value);
+            
+            RegisterNativeIntegrations(hub, options, _options);
             RegisterXamarinLogListener(hub);
 
             //Don't lock the main Thread while you wait for the current application to be created.
@@ -66,17 +65,6 @@ namespace Sentry.Xamarin.Forms
                 });
         }
 
-        internal void RegisterEventProcessors(SentryOptions options)
-        {
-            options.AddEventProcessor(new XamarinFormsEventProcessor(options));
-
-#if NATIVE_PROCESSOR
-            options.AddEventProcessor(new NativeEventProcessor(options));
-#else
-            options.DiagnosticLogger?.Log(SentryLevel.Debug, "No NativeEventProcessor found for the given target.");
-#endif
-        }
-
         internal void RegisterNativeIntegrations(IHub hub, SentryOptions options, SentryXamarinOptions xamarinOptions)
         {
             if (xamarinOptions.NativeIntegrationEnabled)
@@ -92,9 +80,9 @@ namespace Sentry.Xamarin.Forms
 
         internal void RegisterXamarinLogListener(IHub hub)
         {
-            XamarinLogger = new DelegateLogListener((arg1, arg2) =>
+            _xamarinLogger = new DelegateLogListener((arg1, arg2) =>
             {
-                if (Options.Value.XamarinLoggerEnabled)
+                if (_options.XamarinLoggerEnabled)
                 {
                     hub.AddBreadcrumb(null,
                         "xamarin",
@@ -107,15 +95,10 @@ namespace Sentry.Xamarin.Forms
                 }
             });
 
-            if (Options.Value.XamarinLoggerEnabled)
+            if (_options.XamarinLoggerEnabled)
             {
-                Log.Listeners.Add(XamarinLogger);
+                Log.Listeners.Add(_xamarinLogger);
             }
-        }
-
-        internal void ConfigureSentryOptions(SentryOptions options)
-        {
-            options.Release ??= $"{AppInfo.PackageName}@{AppInfo.VersionString}";
         }
 
         /// <summary>

--- a/Sentry.Xamarin.Forms/SentryXamarinOptions.cs
+++ b/Sentry.Xamarin.Forms/SentryXamarinOptions.cs
@@ -1,6 +1,9 @@
-﻿namespace Sentry.Xamarin.Forms.Internals
+﻿namespace Sentry
 {
-    internal class SentryXamarinOptions
+    /// <summary>
+    /// Sentry Xamarin SDK options.
+    /// </summary>
+    public class SentryXamarinOptions : SentryOptions
     {
         internal bool XamarinLoggerEnabled { get; set; } = true;
         internal bool NativeIntegrationEnabled { get; set; } = true;

--- a/Tests/Sentry.Xamarin.Forms.Testing/Sentry.Xamarin.Forms.Testing.csproj
+++ b/Tests/Sentry.Xamarin.Forms.Testing/Sentry.Xamarin.Forms.Testing.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
-
 </Project>

--- a/Tests/Sentry.Xamarin.Forms.Tests.UWP/Extensions/SentryOptionsExtensionsTests.cs
+++ b/Tests/Sentry.Xamarin.Forms.Tests.UWP/Extensions/SentryOptionsExtensionsTests.cs
@@ -14,12 +14,11 @@ namespace Sentry.Xamarin.Forms.Tests.UWP.Extensions
         public void ConfigureSentryOptions_ReleaseSetIfNotInformed()
         {
             //Arrange
-            var options = new SentryOptions();
-            var xamarinOptions = new SentryXamarinOptions();
+            var options = new SentryXamarinOptions();
             options.Release = null;
 
             //Act
-            options.ConfigureSentryXamarinOptions(xamarinOptions);
+            options.ConfigureSentryXamarinOptions();
 
             //Assert
             Assert.NotNull(options.Release);
@@ -29,14 +28,13 @@ namespace Sentry.Xamarin.Forms.Tests.UWP.Extensions
         public void ConfigureSentryOptions_ReleaseNotSetIfInformed()
         {
             //Arrange
-            var options = new SentryOptions()
+            var options = new SentryXamarinOptions()
             {
                 Release = "myrelease@1.1"
             };
-            var xamarinOptions = new SentryXamarinOptions();
 
             //Act
-            options.ConfigureSentryXamarinOptions(xamarinOptions);
+            options.ConfigureSentryXamarinOptions();
 
             //Assert
             Assert.Equal(options.Release, options.Release);
@@ -45,17 +43,14 @@ namespace Sentry.Xamarin.Forms.Tests.UWP.Extensions
         public void ConfigureSentryOptions_DefaultCachePathDisabled_CachePathNotSet()
         {
             //Arrange
-            var options = new SentryOptions()
+            var options = new SentryXamarinOptions()
             {
-                CacheDirectoryPath = null
-            };
-            var xamarinOptions = new SentryXamarinOptions()
-            {
+                CacheDirectoryPath = null,
                 InternalCacheEnabled = false
             };
 
             //Act
-            options.ConfigureSentryXamarinOptions(xamarinOptions);
+            options.ConfigureSentryXamarinOptions();
 
             //Assert
             Assert.Null(options.CacheDirectoryPath);
@@ -65,15 +60,14 @@ namespace Sentry.Xamarin.Forms.Tests.UWP.Extensions
         public void ConfigureSentryOptions_DefaultCachePathEnabledAndCacheDirectoryPathNull_CachePathSet()
         {
             //Arrange
-            var options = new SentryOptions()
+            var options = new SentryXamarinOptions()
             {
                 CacheDirectoryPath = null
             };
-            var xamarinOptions = new SentryXamarinOptions();
             var expectedPath = options.DefaultCacheDirectoyPath();
 
             //Act
-            options.ConfigureSentryXamarinOptions(xamarinOptions);
+            options.ConfigureSentryXamarinOptions();
 
             //Assert
             Assert.Equal(expectedPath, options.CacheDirectoryPath);
@@ -85,14 +79,13 @@ namespace Sentry.Xamarin.Forms.Tests.UWP.Extensions
         {
             //Arrange
             var expectedPath = "./";
-            var options = new SentryOptions()
+            var options = new SentryXamarinOptions()
             {
                 CacheDirectoryPath = expectedPath,
             };
-            var xamarinOptions = new SentryXamarinOptions();
 
             //Act
-            options.ConfigureSentryXamarinOptions(xamarinOptions);
+            options.ConfigureSentryXamarinOptions();
 
             //Assert
             Assert.Equal(expectedPath, options.CacheDirectoryPath);

--- a/Tests/Sentry.Xamarin.Forms.Tests.UWP/Extensions/SentryOptionsExtensionsTests.cs
+++ b/Tests/Sentry.Xamarin.Forms.Tests.UWP/Extensions/SentryOptionsExtensionsTests.cs
@@ -1,0 +1,101 @@
+﻿using Sentry.Xamarin.Forms.Internals;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Sentry.Xamarin.Forms.Tests.UWP.Extensions
+{
+    public class SentryOptionsExtensionsTests
+    {
+        [Fact]
+        public void ConfigureSentryOptions_ReleaseSetIfNotInformed()
+        {
+            //Arrange
+            var options = new SentryOptions();
+            var xamarinOptions = new SentryXamarinOptions();
+            options.Release = null;
+
+            //Act
+            options.ConfigureSentryXamarinOptions(xamarinOptions);
+
+            //Assert
+            Assert.NotNull(options.Release);
+        }
+
+        [Fact]
+        public void ConfigureSentryOptions_ReleaseNotSetIfInformed()
+        {
+            //Arrange
+            var options = new SentryOptions()
+            {
+                Release = "myrelease@1.1"
+            };
+            var xamarinOptions = new SentryXamarinOptions();
+
+            //Act
+            options.ConfigureSentryXamarinOptions(xamarinOptions);
+
+            //Assert
+            Assert.Equal(options.Release, options.Release);
+        }
+        [Fact]
+        public void ConfigureSentryOptions_DefaultCachePathDisabled_CachePathNotSet()
+        {
+            //Arrange
+            var options = new SentryOptions()
+            {
+                CacheDirectoryPath = null
+            };
+            var xamarinOptions = new SentryXamarinOptions()
+            {
+                InternalCacheEnabled = false
+            };
+
+            //Act
+            options.ConfigureSentryXamarinOptions(xamarinOptions);
+
+            //Assert
+            Assert.Null(options.CacheDirectoryPath);
+        }
+
+        [Fact]
+        public void ConfigureSentryOptions_DefaultCachePathEnabledAndCacheDirectoryPathNull_CachePathSet()
+        {
+            //Arrange
+            var options = new SentryOptions()
+            {
+                CacheDirectoryPath = null
+            };
+            var xamarinOptions = new SentryXamarinOptions();
+            var expectedPath = options.DefaultCacheDirectoyPath();
+
+            //Act
+            options.ConfigureSentryXamarinOptions(xamarinOptions);
+
+            //Assert
+            Assert.Equal(expectedPath, options.CacheDirectoryPath);
+            Assert.NotNull(expectedPath);
+        }
+
+        [Fact]
+        public void ConfigureSentryOptions_DefaultCachePathEnabledAndCacheDirectorySet_CachePathSkipped()
+        {
+            //Arrange
+            var expectedPath = "./";
+            var options = new SentryOptions()
+            {
+                CacheDirectoryPath = expectedPath,
+            };
+            var xamarinOptions = new SentryXamarinOptions();
+
+            //Act
+            options.ConfigureSentryXamarinOptions(xamarinOptions);
+
+            //Assert
+            Assert.Equal(expectedPath, options.CacheDirectoryPath);
+        }
+    }
+}

--- a/Tests/Sentry.Xamarin.Forms.Tests.UWP/Extensions/SentryXamarinOptionsExtensionsTests.cs
+++ b/Tests/Sentry.Xamarin.Forms.Tests.UWP/Extensions/SentryXamarinOptionsExtensionsTests.cs
@@ -1,14 +1,8 @@
-﻿using Sentry.Xamarin.Forms.Internals;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Xunit;
+﻿using Xunit;
 
 namespace Sentry.Xamarin.Forms.Tests.UWP.Extensions
 {
-    public class SentryOptionsExtensionsTests
+    public class SentryXamarinOptionsExtensionsTests
     {
         [Fact]
         public void ConfigureSentryOptions_ReleaseSetIfNotInformed()

--- a/Tests/Sentry.Xamarin.Forms.Tests.UWP/Sentry.Xamarin.Forms.Tests.UWP.csproj
+++ b/Tests/Sentry.Xamarin.Forms.Tests.UWP/Sentry.Xamarin.Forms.Tests.UWP.csproj
@@ -119,6 +119,7 @@
     <SDKReference Include="TestPlatform.Universal, Version=$(UnitTestPlatformVersion)" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Extensions\SentryOptionsExtensionsTests.cs" />
     <Compile Include="Internals\FormsEventProcessorTests.cs" />
     <Compile Include="Internals\NativeEventProcessorTests.cs" />
     <Compile Include="Internals\NativeIntegrationTests.cs" />
@@ -180,6 +181,7 @@
       <Name>Sentry.Xamarin.Forms</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup />
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>

--- a/Tests/Sentry.Xamarin.Forms.Tests.UWP/Sentry.Xamarin.Forms.Tests.UWP.csproj
+++ b/Tests/Sentry.Xamarin.Forms.Tests.UWP/Sentry.Xamarin.Forms.Tests.UWP.csproj
@@ -119,7 +119,7 @@
     <SDKReference Include="TestPlatform.Universal, Version=$(UnitTestPlatformVersion)" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Extensions\SentryOptionsExtensionsTests.cs" />
+    <Compile Include="Extensions\SentryXamarinOptionsExtensionsTests.cs" />
     <Compile Include="Internals\FormsEventProcessorTests.cs" />
     <Compile Include="Internals\NativeEventProcessorTests.cs" />
     <Compile Include="Internals\NativeIntegrationTests.cs" />

--- a/Tests/Sentry.Xamarin.Forms.Tests.UWP/SentryXamarinFormsIntegrationTests.cs
+++ b/Tests/Sentry.Xamarin.Forms.Tests.UWP/SentryXamarinFormsIntegrationTests.cs
@@ -4,44 +4,14 @@ using Xunit;
 namespace Sentry.Xamarin.Forms.Tests.UWP
 {
     public class SentryXamarinFormsIntegrationTests
-    {
-        [Fact]
-        public void ConfigureSentryOptions_ReleaseSetIfNotInformed()
-        {
-            //Arrange
-            var options = new SentryOptions();
-            options.Release = null;
-            var integration = new SentryXamarinFormsIntegration();
-
-            //Act
-            integration.ConfigureSentryOptions(options);
-
-            //Assert
-            Assert.NotNull(options.Release);
-        }
-
-        [Fact]
-        public void ConfigureSentryOptions_ReleaseNotSetIfInformed()
-        {
-            //Arrange
-            var options = new SentryOptions();
-            options.Release = "myrelease@1.1";
-            var integration = new SentryXamarinFormsIntegration();
-
-            //Act
-            integration.ConfigureSentryOptions(options);
-
-            //Assert
-            Assert.Equal(options.Release, options.Release);
-        }
-        
+    {        
         [Fact]
         public void RegisterNativeIntegrations_NativeIntegrationEnabled_NativeIntegrationRegistered()
         {
             //Arrange
             var options = new SentryOptions();
             var xamarinOptions = new SentryXamarinOptions();
-            var integration = new SentryXamarinFormsIntegration();
+            var integration = new SentryXamarinFormsIntegration(xamarinOptions);
 
             //Act
             integration.RegisterNativeIntegrations(default, options, xamarinOptions);
@@ -60,7 +30,7 @@ namespace Sentry.Xamarin.Forms.Tests.UWP
             {
                 NativeIntegrationEnabled = false
             };
-            var integration = new SentryXamarinFormsIntegration();
+            var integration = new SentryXamarinFormsIntegration(xamarinOptions);
 
             //Act
             integration.RegisterNativeIntegrations(default, options, xamarinOptions);


### PR DESCRIPTION
- Created API Initializer.
- moved some code from SentryXamarinFormsIntegration to SentryXamarin and SentryOptionsExtensions.
- Automatically Set the Cache Directory path once initialized.
- Add Extension for disabling the Automatic Cache Folder setter.
- Updated tests.

Initialization changes:
Before:
```
        SentrySdk.Init(o =>
        {
            o.Dsn = "https://5a193123a9b841bc8d8e42531e7242a1@o447951.ingest.sentry.io/5560112";
            o.CacheDirectoryPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
            o.AddIntegration(new SentryXamarinFormsIntegration());
        });
```

After:
```
            SentryXamarin.Init(options =>
            {
                options.Dsn = "https://5a193123a9b841bc8d8e42531e7242a1@o447951.ingest.sentry.io/5560112";
            });
```

Operations like WithScope, ConfigureScope, CaptureMessage weren't changed so the Developer will call SentrySdk for performing the operations implemented by SentrySdk.