### PR TITLE
Ref: Update Sentry .NET SDK and fixed conflicts.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Deterministic>true</Deterministic>
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="Sentry" Version="3.0.0" />
+	<PackageReference Include="Sentry" Version="3.0.1" />
     <PackageReference Include="Roslynator.Analyzers" Version="3.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.1" PrivateAssets="All" />

--- a/Src/Sentry.Xamarin/Internals/DeviceModel.ios.cs
+++ b/Src/Sentry.Xamarin/Internals/DeviceModel.ios.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 using Foundation;
-using ObjCRuntime;
+using iOSConstants = ObjCRuntime.Constants;
 /* Credits: dannycabrera
 /* Source: https://github.com/dannycabrera/Get-iOS-Model
 */
@@ -13,7 +13,7 @@ namespace Sentry.Xamarin.Internals
     {
         private const string _hardwareProperty = "hw.machine";
 
-        [DllImport(Constants.SystemLibrary)]
+        [DllImport(iOSConstants.SystemLibrary)]
         private extern static int sysctlbyname([MarshalAs(UnmanagedType.LPStr)] string property,
                                         IntPtr output,
                                         IntPtr oldLen,

--- a/Src/Sentry.Xamarin/Internals/NativeEventProcessor.uwp.cs
+++ b/Src/Sentry.Xamarin/Internals/NativeEventProcessor.uwp.cs
@@ -1,8 +1,8 @@
 ﻿using Sentry.Extensibility;
 using System;
-using Windows.ApplicationModel;
 using Windows.Security.ExchangeActiveSyncProvisioning;
 using Windows.System.Profile;
+using UwpPackage = Windows.ApplicationModel.Package;
 
 namespace Sentry.Xamarin.Internals
 {
@@ -34,7 +34,7 @@ namespace Sentry.Xamarin.Internals
                 var revision = (version & 0x000000000000FFFFL);
                 OsVersion = $"{major}.{minor}.{build}.{revision}";
 
-                OsArchitecture = Package.Current.Id.Architecture.ToString();
+                OsArchitecture = UwpPackage.Current.Id.Architecture.ToString();
                 var deviceInfo = new EasClientDeviceInformation();
                 OsName = char.ToUpper(deviceInfo.OperatingSystem[0]) + 
                     deviceInfo.OperatingSystem.Remove(0,1).ToLower();

--- a/Src/Sentry.Xamarin/Internals/NativeIntegration.ios.cs
+++ b/Src/Sentry.Xamarin/Internals/NativeIntegration.ios.cs
@@ -1,5 +1,4 @@
 ﻿using Foundation;
-using ObjCRuntime;
 using Sentry.Integrations;
 using Sentry.Protocol;
 using System;

--- a/Src/Sentry.Xamarin/Internals/NativeIntegration.uwp.cs
+++ b/Src/Sentry.Xamarin/Internals/NativeIntegration.uwp.cs
@@ -5,6 +5,7 @@ using System.Runtime.ExceptionServices;
 using System.Security;
 using Windows.ApplicationModel;
 using Windows.UI.Xaml;
+using UwpUnhandledExceptionEventArgs = Windows.UI.Xaml.UnhandledExceptionEventArgs;
 
 namespace Sentry.Xamarin.Internals
 {
@@ -43,7 +44,7 @@ namespace Sentry.Xamarin.Internals
         }
 
         [HandleProcessCorruptedStateExceptions, SecurityCritical]
-        internal void NativeHandle(object sender, Windows.UI.Xaml.UnhandledExceptionEventArgs e)
+        internal void NativeHandle(object sender, UwpUnhandledExceptionEventArgs e)
         {
             //We need to backup the reference, because the Exception reference last for one access.
             //After that, a new  Exception reference is going to be set into e.Exception.


### PR DESCRIPTION
Sentry .NET SDK 3.0.1 breaks the release 1.0.0 so I'm updating the SDK to be compatible with it.