### PR TITLE
Fix: PlatformNotSupportedException on UWP Exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+* Fix exceptions not being registered on UWP projects. (#47) @lucas-zimerman
 * Add available RAM parameter (Android). (#46) @lucas-zimerman
 
 ## 1.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changes
 
-* Fix exceptions not being registered on UWP projects. (#47) @lucas-zimerman
+* Fix exceptions not being registered on UWP projects. (#49) @lucas-zimerman
 * Add available RAM parameter (Android). (#46) @lucas-zimerman
 
 ## 1.0.1

--- a/Src/Sentry.Xamarin/Internals/NativeIntegration.uwp.cs
+++ b/Src/Sentry.Xamarin/Internals/NativeIntegration.uwp.cs
@@ -14,7 +14,12 @@ namespace Sentry.Xamarin.Internals
         private IHub _hub;
         private Application _application;
 
-        internal NativeIntegration(SentryXamarinOptions options) { }
+        internal NativeIntegration(SentryXamarinOptions options) 
+        {
+            //Ben Demystifier doesn't support .NET Native so we have to force it to Original.
+            //See: https://github.com/benaadams/Ben.Demystifier/issues/51#issuecomment-777311071
+            options.StackTraceMode = StackTraceMode.Original;
+        }
 
         /// <summary>
         /// Initialize the UWP specific code.


### PR DESCRIPTION
Ben Demystifier doesn't support .NET Native so we have to disable it for the UWP platform.

See https://github.com/benaadams/Ben.Demystifier/issues/51#issuecomment-777311071 for more information.